### PR TITLE
Catch Throwables to avoid a problem when PHP7 throws an Error

### DIFF
--- a/lib/jpgraph/src/jpgraph_errhandler.inc.php
+++ b/lib/jpgraph/src/jpgraph_errhandler.inc.php
@@ -155,7 +155,7 @@ class JpGraphException extends Exception {
     	}
         $errobj->Raise($this->getMessage());
     }
-    static public function defaultHandler(Exception $exception) {
+    static public function defaultHandler(Throwable $exception) {
         global $__jpg_OldHandler;
         if( $exception instanceof JpGraphException ) {
             $exception->Stroke();


### PR DESCRIPTION
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to JpGraphException::defaultHandler() must be an instance of Exception, instance of Error given